### PR TITLE
refactor impl Display for Table

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 
 rust:
   - stable
-  - nightly
 
 os:
   - linux
@@ -32,6 +31,9 @@ branches:
 
 matrix:
   allow_failures:
+    - rust: nightly
+
+  include:
     - rust: nightly
 
     addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - rust: nightly
 
   include:
-    - rust: nightly
+  - rust: nightly
 
     addons:
       apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ matrix:
 
     script:
     - cargo fmt -- --check
-    - cargo clippy --features clippy -- -D warnings
+    - cargo clippy -- -D warnings
     - cargo test
 
     after_success:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ description = "Yet another format-preserving TOML parser."
 authors = ["Andronik Ordian <write@reusable.software>"]
 repository = "https://github.com/ordian/toml_edit"
 documentation = "https://docs.rs/toml_edit"
+edition = "2018"
 
 [badges]
 travis-ci = { repository = "ordian/toml_edit" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,3 @@ serde_json = "1.0.27"
 
 [profile.dev]
 opt-level = 1
-
-[features]
-default = []
-clippy = []

--- a/src/array_of_tables.rs
+++ b/src/array_of_tables.rs
@@ -1,4 +1,4 @@
-use table::{Item, Table};
+use crate::table::{Item, Table};
 
 /// Type representing a TOML array of tables
 #[derive(Clone, Debug, Default)]
@@ -8,7 +8,7 @@ pub struct ArrayOfTables {
 }
 
 /// An iterator type over `ArrayOfTables`'s values.
-type ArrayOfTablesIter<'a> = Box<Iterator<Item = &'a Table> + 'a>;
+type ArrayOfTablesIter<'a> = Box<dyn Iterator<Item = &'a Table> + 'a>;
 
 impl ArrayOfTables {
     /// Creates an empty array of tables.

--- a/src/display.rs
+++ b/src/display.rs
@@ -2,7 +2,6 @@ use crate::decor::{Formatted, Repr};
 use crate::document::Document;
 use crate::table::{Item, Table};
 use crate::value::{Array, DateTime, InlineTable, Value};
-use std::cell::{Cell, RefCell};
 use std::fmt::{Display, Formatter, Result};
 
 impl Display for Repr {
@@ -114,10 +113,10 @@ impl Table {
 fn visit_table(
     f: &mut Formatter,
     table: &Table,
-    path: &Vec<&str>,
+    path: &[&str],
     is_array_of_tables: bool,
 ) -> Result {
-    if path.len() == 0 {
+    if path.is_empty() {
         // don't print header for the root node
     } else if is_array_of_tables {
         write!(f, "{}[[", table.decor.prefix)?;

--- a/src/display.rs
+++ b/src/display.rs
@@ -1,9 +1,9 @@
-use decor::{Formatted, Repr};
-use document::Document;
+use crate::decor::{Formatted, Repr};
+use crate::document::Document;
+use crate::table::{Item, Table};
+use crate::value::{Array, DateTime, InlineTable, Value};
 use std::cell::{Cell, RefCell};
 use std::fmt::{Display, Formatter, Result};
-use table::{Item, Table};
-use value::{Array, DateTime, InlineTable, Value};
 
 impl Display for Repr {
     fn fmt(&self, f: &mut Formatter) -> Result {

--- a/src/document.rs
+++ b/src/document.rs
@@ -1,7 +1,7 @@
-use decor::InternalString;
-use parser;
+use crate::decor::InternalString;
+use crate::parser;
+use crate::table::{Item, Iter, Table};
 use std::str::FromStr;
-use table::{Item, Iter, Table};
 
 /// Type representing a TOML document
 #[derive(Debug, Clone)]

--- a/src/formatted.rs
+++ b/src/formatted.rs
@@ -1,10 +1,10 @@
-use combine::stream::state::State;
 use crate::decor::{Decor, Formatted, InternalString, Repr};
 use crate::key::Key;
 use crate::parser::strings;
 use crate::parser::TomlError;
 use crate::table::{Item, KeyValuePairs, TableKeyValue};
 use crate::value::{Array, DateTime, InlineTable, Value};
+use combine::stream::state::State;
 use std::iter::FromIterator;
 
 pub(crate) fn decorate_array(array: &mut Array) {

--- a/src/formatted.rs
+++ b/src/formatted.rs
@@ -1,11 +1,11 @@
 use combine::stream::state::State;
-use decor::{Decor, Formatted, InternalString, Repr};
-use key::Key;
-use parser::strings;
-use parser::TomlError;
+use crate::decor::{Decor, Formatted, InternalString, Repr};
+use crate::key::Key;
+use crate::parser::strings;
+use crate::parser::TomlError;
+use crate::table::{Item, KeyValuePairs, TableKeyValue};
+use crate::value::{Array, DateTime, InlineTable, Value};
 use std::iter::FromIterator;
-use table::{Item, KeyValuePairs, TableKeyValue};
-use value::{Array, DateTime, InlineTable, Value};
 
 pub(crate) fn decorate_array(array: &mut Array) {
     for (i, val) in array

--- a/src/index.rs
+++ b/src/index.rs
@@ -1,8 +1,8 @@
-use document::Document;
-use formatted::to_table_key_value;
+use crate::document::Document;
+use crate::formatted::to_table_key_value;
+use crate::table::{value, Item, Table};
+use crate::value::{InlineTable, Value};
 use std::ops;
-use table::{value, Item, Table};
-use value::{InlineTable, Value};
 
 // copied from
 // https://github.com/serde-rs/json/blob/master/src/value/index.rs

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
 use combine::stream::state::State;
-use decor::InternalString;
-use parser;
+use crate::decor::InternalString;
+use crate::parser;
 use std::str::FromStr;
 
 /// Key as part of a Key/Value Pair or a table header.

--- a/src/key.rs
+++ b/src/key.rs
@@ -1,6 +1,6 @@
-use combine::stream::state::State;
 use crate::decor::InternalString;
 use crate::parser;
+use combine::stream::state::State;
 use std::str::FromStr;
 
 /// Key as part of a Key/Value Pair or a table header.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![cfg_attr(feature = "clippy", feature(tool_lints))]
 #![deny(missing_docs)]
 #![deny(warnings)]
 // https://github.com/Marwes/combine/issues/172
@@ -71,9 +70,6 @@
 //! and an easy to use and type-safe API.
 //!
 //! [test]: https://github.com/ordian/toml_edit/blob/f09bd5d075fdb7d2ef8d9bb3270a34506c276753/tests/test_valid.rs#L84
-extern crate chrono;
-extern crate combine;
-extern crate linked_hash_map;
 
 mod array_of_tables;
 mod decor;
@@ -86,9 +82,9 @@ mod parser;
 mod table;
 mod value;
 
-pub use array_of_tables::ArrayOfTables;
-pub use document::Document;
-pub use key::Key;
-pub use parser::TomlError;
-pub use table::{array, table, value, Item, Iter, Table, TableLike};
-pub use value::{Array, InlineTable, Value};
+pub use crate::array_of_tables::ArrayOfTables;
+pub use crate::document::Document;
+pub use crate::key::Key;
+pub use crate::parser::TomlError;
+pub use crate::table::{array, table, value, Item, Iter, Table, TableLike};
+pub use crate::value::{Array, InlineTable, Value};

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -1,13 +1,13 @@
-use combine::char::char;
-use combine::range::recognize_with_value;
-use combine::stream::RangeStream;
-use combine::*;
 use crate::decor::InternalString;
 use crate::formatted::decorated;
 use crate::parser::errors::CustomError;
 use crate::parser::trivia::ws_comment_newline;
 use crate::parser::value::value;
 use crate::value::{Array, Value};
+use combine::char::char;
+use combine::range::recognize_with_value;
+use combine::stream::RangeStream;
+use combine::*;
 
 // ;; Array
 

--- a/src/parser/array.rs
+++ b/src/parser/array.rs
@@ -2,12 +2,12 @@ use combine::char::char;
 use combine::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
-use decor::InternalString;
-use formatted::decorated;
-use parser::errors::CustomError;
-use parser::trivia::ws_comment_newline;
-use parser::value::value;
-use value::{Array, Value};
+use crate::decor::InternalString;
+use crate::formatted::decorated;
+use crate::parser::errors::CustomError;
+use crate::parser::trivia::ws_comment_newline;
+use crate::parser::value::value;
+use crate::value::{Array, Value};
 
 // ;; Array
 

--- a/src/parser/datetime.rs
+++ b/src/parser/datetime.rs
@@ -4,7 +4,7 @@ use combine::combinator::{skip_count_min_max, SkipCountMinMax};
 use combine::range::{recognize, recognize_with_value};
 use combine::stream::RangeStream;
 use combine::*;
-use value;
+use crate::value;
 
 #[inline]
 pub fn repeat<P: Parser>(count: usize, parser: P) -> SkipCountMinMax<P> {

--- a/src/parser/datetime.rs
+++ b/src/parser/datetime.rs
@@ -1,10 +1,10 @@
+use crate::value;
 use chrono;
 use combine::char::{char, digit};
 use combine::combinator::{skip_count_min_max, SkipCountMinMax};
 use combine::range::{recognize, recognize_with_value};
 use combine::stream::RangeStream;
 use combine::*;
-use crate::value;
 
 #[inline]
 pub fn repeat<P: Parser>(count: usize, parser: P) -> SkipCountMinMax<P> {

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -1,23 +1,23 @@
+use std::cell::RefCell;
+use std::mem;
+use std::ops::DerefMut;
 use combine::char::char;
 use combine::range::recognize;
 use combine::stream::state::State;
 use combine::stream::RangeStream;
 use combine::Parser;
 use combine::*;
-use decor::{InternalString, Repr};
-use document::Document;
-use formatted::decorated;
-use parser::errors::CustomError;
-use parser::inline_table::KEYVAL_SEP;
-use parser::key::key;
-use parser::table::table;
-use parser::trivia::{comment, line_ending, line_trailing, newline, ws};
-use parser::value::value;
-use parser::{TomlError, TomlParser};
-use std::cell::RefCell;
-use std::mem;
-use std::ops::DerefMut;
-use table::{Item, TableKeyValue};
+use crate::decor::{InternalString, Repr};
+use crate::document::Document;
+use crate::formatted::decorated;
+use crate::parser::errors::CustomError;
+use crate::parser::inline_table::KEYVAL_SEP;
+use crate::parser::key::key;
+use crate::parser::table::table;
+use crate::parser::trivia::{comment, line_ending, line_trailing, newline, ws};
+use crate::parser::value::value;
+use crate::parser::{TomlError, TomlParser};
+use crate::table::{Item, TableKeyValue};
 
 toml_parser!(parse_comment, parser, {
     (comment(), line_ending()).map(|(c, e)| parser.borrow_mut().deref_mut().on_comment(c, e))
@@ -44,10 +44,10 @@ parser! {
          Item = char>,
          I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
          <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
-         From<::std::num::ParseIntError> +
-         From<::std::num::ParseFloatError> +
-         From<::chrono::ParseError> +
-         From<::parser::errors::CustomError>
+         From<std::num::ParseIntError> +
+         From<std::num::ParseFloatError> +
+         From<chrono::ParseError> +
+         From<crate::parser::errors::CustomError>
     ] {
         (
             (key(), ws()),

--- a/src/parser/document.rs
+++ b/src/parser/document.rs
@@ -1,12 +1,3 @@
-use std::cell::RefCell;
-use std::mem;
-use std::ops::DerefMut;
-use combine::char::char;
-use combine::range::recognize;
-use combine::stream::state::State;
-use combine::stream::RangeStream;
-use combine::Parser;
-use combine::*;
 use crate::decor::{InternalString, Repr};
 use crate::document::Document;
 use crate::formatted::decorated;
@@ -18,6 +9,15 @@ use crate::parser::trivia::{comment, line_ending, line_trailing, newline, ws};
 use crate::parser::value::value;
 use crate::parser::{TomlError, TomlParser};
 use crate::table::{Item, TableKeyValue};
+use combine::char::char;
+use combine::range::recognize;
+use combine::stream::state::State;
+use combine::stream::RangeStream;
+use combine::Parser;
+use combine::*;
+use std::cell::RefCell;
+use std::mem;
+use std::ops::DerefMut;
 
 toml_parser!(parse_comment, parser, {
     (comment(), line_ending()).map(|(c, e)| parser.borrow_mut().deref_mut().on_comment(c, e))

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -1,14 +1,14 @@
 use combine::char::char;
 use combine::stream::RangeStream;
 use combine::*;
-use decor::{InternalString, Repr};
-use formatted::decorated;
-use parser::errors::CustomError;
-use parser::key::key;
-use parser::trivia::ws;
-use parser::value::value;
-use table::{Item, TableKeyValue};
-use value::InlineTable;
+use crate::decor::{InternalString, Repr};
+use crate::formatted::decorated;
+use crate::parser::errors::CustomError;
+use crate::parser::key::key;
+use crate::parser::trivia::ws;
+use crate::parser::value::value;
+use crate::table::{Item, TableKeyValue};
+use crate::value::InlineTable;
 
 // ;; Inline Table
 

--- a/src/parser/inline_table.rs
+++ b/src/parser/inline_table.rs
@@ -1,6 +1,3 @@
-use combine::char::char;
-use combine::stream::RangeStream;
-use combine::*;
 use crate::decor::{InternalString, Repr};
 use crate::formatted::decorated;
 use crate::parser::errors::CustomError;
@@ -9,6 +6,9 @@ use crate::parser::trivia::ws;
 use crate::parser::value::value;
 use crate::table::{Item, TableKeyValue};
 use crate::value::InlineTable;
+use combine::char::char;
+use combine::stream::RangeStream;
+use combine::*;
 
 // ;; Inline Table
 

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -1,13 +1,13 @@
 use combine::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
-use decor::InternalString;
-use parser::strings::{basic_string, literal_string};
+use crate::decor::InternalString;
+use crate::parser::strings::{basic_string, literal_string};
 
 #[inline]
 fn is_unquoted_char(c: char) -> bool {
     match c {
-        'A'...'Z' | 'a'...'z' | '0'...'9' | '-' | '_' => true,
+        'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' => true,
         _ => false,
     }
 }

--- a/src/parser/key.rs
+++ b/src/parser/key.rs
@@ -1,8 +1,8 @@
+use crate::decor::InternalString;
+use crate::parser::strings::{basic_string, literal_string};
 use combine::range::{recognize_with_value, take_while1};
 use combine::stream::RangeStream;
 use combine::*;
-use crate::decor::InternalString;
-use crate::parser::strings::{basic_string, literal_string};
 
 #[inline]
 fn is_unquoted_char(c: char) -> bool {

--- a/src/parser/macros.rs
+++ b/src/parser/macros.rs
@@ -10,10 +10,10 @@ macro_rules! parse (
                  Item = char>,
                  I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
                  <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
-                 From<::std::num::ParseIntError> +
-                 From<::std::num::ParseFloatError> +
-                 From<::chrono::ParseError> +
-                 From<::parser::errors::CustomError>
+                 From<std::num::ParseIntError> +
+                 From<std::num::ParseFloatError> +
+                 From<chrono::ParseError> +
+                 From<crate::parser::errors::CustomError>
             ]            {
                 $code
             }
@@ -33,10 +33,10 @@ macro_rules! toml_parser (
                  Item = char>,
                  I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
                  <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
-                 From<::std::num::ParseIntError> +
-                 From<::std::num::ParseFloatError> +
-                 From<::chrono::ParseError> +
-                 From<::parser::errors::CustomError>
+                 From<std::num::ParseIntError> +
+                 From<std::num::ParseFloatError> +
+                 From<chrono::ParseError> +
+                 From<crate::parser::errors::CustomError>
             ]    {
                 $closure
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -1,5 +1,5 @@
-#![cfg_attr(feature = "clippy", allow(clippy::unneeded_field_pattern))]
-#![cfg_attr(feature = "clippy", allow(clippy::toplevel_ref_arg))]
+#![allow(clippy::unneeded_field_pattern)]
+#![allow(clippy::toplevel_ref_arg)]
 
 #[macro_use]
 mod macros;
@@ -19,8 +19,8 @@ pub use self::errors::TomlError;
 pub(crate) use self::key::key as key_parser;
 pub(crate) use self::value::value as value_parser;
 
-use document::Document;
-use table::Table;
+use crate::document::Document;
+use crate::table::Table;
 
 pub struct TomlParser {
     document: Box<Document>,
@@ -42,8 +42,7 @@ impl Default for TomlParser {
 mod tests {
     use combine::stream::state::State;
     use combine::*;
-    use parser::*;
-    use std;
+    use crate::parser::*;
 
     macro_rules! parsed_eq {
         ($parsed:ident, $expected:expr) => {{

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -40,9 +40,9 @@ impl Default for TomlParser {
 
 #[cfg(test)]
 mod tests {
+    use crate::parser::*;
     use combine::stream::state::State;
     use combine::*;
-    use crate::parser::*;
 
     macro_rules! parsed_eq {
         ($parsed:ident, $expected:expr) => {{

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -1,11 +1,11 @@
+use crate::decor::InternalString;
+use crate::parser::errors::CustomError;
+use crate::parser::trivia::{newline, ws, ws_newlines};
 use combine::char::char;
 use combine::error::{Consumed, Info};
 use combine::range::{range, take, take_while};
 use combine::stream::RangeStream;
 use combine::*;
-use crate::decor::InternalString;
-use crate::parser::errors::CustomError;
-use crate::parser::trivia::{newline, ws, ws_newlines};
 use std::char;
 
 // ;; String

--- a/src/parser/strings.rs
+++ b/src/parser/strings.rs
@@ -3,9 +3,9 @@ use combine::error::{Consumed, Info};
 use combine::range::{range, take, take_while};
 use combine::stream::RangeStream;
 use combine::*;
-use decor::InternalString;
-use parser::errors::CustomError;
-use parser::trivia::{newline, ws, ws_newlines};
+use crate::decor::InternalString;
+use crate::parser::errors::CustomError;
+use crate::parser::trivia::{newline, ws, ws_newlines};
 use std::char;
 
 // ;; String
@@ -24,7 +24,7 @@ parse!(string() -> InternalString, {
 #[inline]
 fn is_basic_unescaped(c: char) -> bool {
     match c {
-        '\u{20}'...'\u{21}' | '\u{23}'...'\u{5B}' | '\u{5D}'...'\u{10FFFF}' => true,
+        '\u{20}'..='\u{21}' | '\u{23}'..='\u{5B}' | '\u{5D}'..='\u{10FFFF}' => true,
         _ => false,
     }
 }
@@ -103,7 +103,7 @@ parse!(basic_string() -> InternalString, {
 #[inline]
 fn is_ml_basic_unescaped(c: char) -> bool {
     match c {
-        '\u{20}'...'\u{5B}' | '\u{5D}'...'\u{10FFFF}' => true,
+        '\u{20}'..='\u{5B}' | '\u{5D}'..='\u{10FFFF}' => true,
         _ => false,
     }
 }
@@ -172,7 +172,7 @@ const APOSTROPHE: char = '\'';
 #[inline]
 fn is_literal_char(c: char) -> bool {
     match c {
-        '\u{09}' | '\u{20}'...'\u{26}' | '\u{28}'...'\u{10FFFF}' => true,
+        '\u{09}' | '\u{20}'..='\u{26}' | '\u{28}'..='\u{10FFFF}' => true,
         _ => false,
     }
 }
@@ -193,7 +193,7 @@ const ML_LITERAL_STRING_DELIM: &str = "'''";
 #[inline]
 fn is_ml_literal_char(c: char) -> bool {
     match c {
-        '\u{09}' | '\u{20}'...'\u{10FFFF}' => true,
+        '\u{09}' | '\u{20}'..='\u{10FFFF}' => true,
         _ => false,
     }
 }

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -1,17 +1,17 @@
-use array_of_tables::ArrayOfTables;
 use combine::char::char;
 use combine::range::range;
 use combine::stream::RangeStream;
 use combine::*;
-use decor::{Decor, InternalString};
-use key::Key;
-use parser::errors::CustomError;
-use parser::key::key;
-use parser::trivia::{line_trailing, ws};
-use parser::TomlParser;
+use crate::array_of_tables::ArrayOfTables;
+use crate::decor::{Decor, InternalString};
+use crate::key::Key;
+use crate::parser::errors::CustomError;
+use crate::parser::key::key;
+use crate::parser::trivia::{line_trailing, ws};
+use crate::parser::TomlParser;
+use crate::table::{Item, Table};
 use std::cell::RefCell;
 use std::mem;
-use table::{Item, Table};
 // https://github.com/rust-lang/rust/issues/41358
 #[allow(unused_imports)]
 use std::ops::DerefMut;
@@ -71,10 +71,10 @@ parser! {
          Item = char>,
          I::Error: ParseError<char, &'a str, <I as StreamOnce>::Position>,
          <I::Error as ParseError<char, &'a str, <I as StreamOnce>::Position>>::StreamError:
-         From<::std::num::ParseIntError> +
-         From<::std::num::ParseFloatError> +
-         From<::chrono::ParseError> +
-         From<::parser::errors::CustomError>
+         From<std::num::ParseIntError> +
+         From<std::num::ParseFloatError> +
+         From<chrono::ParseError> +
+         From<crate::parser::errors::CustomError>
     ]    {
         array_table(parser)
             .or(std_table(parser))

--- a/src/parser/table.rs
+++ b/src/parser/table.rs
@@ -1,7 +1,3 @@
-use combine::char::char;
-use combine::range::range;
-use combine::stream::RangeStream;
-use combine::*;
 use crate::array_of_tables::ArrayOfTables;
 use crate::decor::{Decor, InternalString};
 use crate::key::Key;
@@ -10,6 +6,10 @@ use crate::parser::key::key;
 use crate::parser::trivia::{line_trailing, ws};
 use crate::parser::TomlParser;
 use crate::table::{Item, Table};
+use combine::char::char;
+use combine::range::range;
+use combine::stream::RangeStream;
+use combine::*;
 use std::cell::RefCell;
 use std::mem;
 // https://github.com/rust-lang/rust/issues/41358

--- a/src/parser/trivia.rs
+++ b/src/parser/trivia.rs
@@ -22,7 +22,7 @@ parse!(ws() -> &'a str, {
 #[inline]
 fn is_non_eol(c: char) -> bool {
     match c {
-        '\u{09}' | '\u{20}'...'\u{10FFFF}' => true,
+        '\u{09}' | '\u{20}'..='\u{10FFFF}' => true,
         _ => false,
     }
 }

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -1,14 +1,14 @@
 use combine::range::recognize_with_value;
 use combine::stream::RangeStream;
 use combine::*;
-use decor::{Formatted, Repr};
-use formatted;
-use parser::array::array;
-use parser::datetime::date_time;
-use parser::inline_table::inline_table;
-use parser::numbers::{boolean, float, integer};
-use parser::strings::string;
-use value as v;
+use crate::decor::{Formatted, Repr};
+use crate::formatted;
+use crate::parser::array::array;
+use crate::parser::datetime::date_time;
+use crate::parser::inline_table::inline_table;
+use crate::parser::numbers::{boolean, float, integer};
+use crate::parser::strings::string;
+use crate::value as v;
 
 // val = string / boolean / array / inline-table / date-time / float / integer
 parse!(value() -> v::Value, {

--- a/src/parser/value.rs
+++ b/src/parser/value.rs
@@ -1,6 +1,3 @@
-use combine::range::recognize_with_value;
-use combine::stream::RangeStream;
-use combine::*;
 use crate::decor::{Formatted, Repr};
 use crate::formatted;
 use crate::parser::array::array;
@@ -9,6 +6,9 @@ use crate::parser::inline_table::inline_table;
 use crate::parser::numbers::{boolean, float, integer};
 use crate::parser::strings::string;
 use crate::value as v;
+use combine::range::recognize_with_value;
+use combine::stream::RangeStream;
+use combine::*;
 
 // val = string / boolean / array / inline-table / date-time / float / integer
 parse!(value() -> v::Value, {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,9 +1,9 @@
-use array_of_tables::ArrayOfTables;
-use decor::{Decor, InternalString, Repr};
-use formatted::{decorated, key_repr};
-use key::Key;
+use crate::array_of_tables::ArrayOfTables;
+use crate::decor::{Decor, InternalString, Repr};
+use crate::formatted::{decorated, key_repr};
+use crate::key::Key;
+use crate::value::{sort_key_value_pairs, Array, DateTime, InlineTable, Value};
 use linked_hash_map::LinkedHashMap;
-use value::{sort_key_value_pairs, Array, DateTime, InlineTable, Value};
 
 // TODO: add method to convert a table into inline table
 
@@ -53,7 +53,7 @@ impl TableKeyValue {
 }
 
 /// An iterator type over `Table`'s key/value pairs.
-pub type Iter<'a> = Box<Iterator<Item = (&'a str, &'a Item)> + 'a>;
+pub type Iter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Item)> + 'a>;
 
 impl Table {
     /// Creates an empty table.
@@ -339,10 +339,10 @@ impl Item {
     }
 
     /// Casts `self` to either a table or an inline table.
-    pub fn as_table_like(&self) -> Option<&TableLike> {
+    pub fn as_table_like(&self) -> Option<&dyn TableLike> {
         self.as_table()
-            .map(|t| t as &TableLike)
-            .or_else(|| self.as_inline_table().map(|t| t as &TableLike))
+            .map(|t| t as &dyn TableLike)
+            .or_else(|| self.as_inline_table().map(|t| t as &dyn TableLike))
     }
 
     /// Returns true iff `self` is either a table, or an inline table.

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,13 +1,13 @@
 use chrono::{self, FixedOffset};
 use combine::stream::state::State;
-use decor::{Decor, Formatted, InternalString};
-use formatted;
-use key::Key;
+use crate::decor::{Decor, Formatted, InternalString};
+use crate::formatted;
+use crate::key::Key;
+use crate::parser;
+use crate::table::{Item, Iter, KeyValuePairs, TableKeyValue, TableLike};
 use linked_hash_map::LinkedHashMap;
-use parser;
 use std::mem;
 use std::str::FromStr;
-use table::{Item, Iter, KeyValuePairs, TableKeyValue, TableLike};
 
 /// Representation of a TOML Value (as part of a Key/Value Pair).
 #[derive(Debug, Clone)]
@@ -80,7 +80,7 @@ pub(crate) enum ValueType {
 }
 
 /// An iterator type over `Array`'s values.
-pub type ArrayIter<'a> = Box<Iterator<Item = &'a Value> + 'a>;
+pub type ArrayIter<'a> = Box<dyn Iterator<Item = &'a Value> + 'a>;
 
 impl Array {
     /// Returns the length of the underlying Vec.
@@ -151,7 +151,7 @@ impl Array {
 }
 
 /// An iterator type over key/value pairs of an inline table.
-pub type InlineTableIter<'a> = Box<Iterator<Item = (&'a str, &'a Value)> + 'a>;
+pub type InlineTableIter<'a> = Box<dyn Iterator<Item = (&'a str, &'a Value)> + 'a>;
 
 impl InlineTable {
     /// Returns the number of key/value pairs.

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,10 +1,10 @@
-use chrono::{self, FixedOffset};
-use combine::stream::state::State;
 use crate::decor::{Decor, Formatted, InternalString};
 use crate::formatted;
 use crate::key::Key;
 use crate::parser;
 use crate::table::{Item, Iter, KeyValuePairs, TableKeyValue, TableLike};
+use chrono::{self, FixedOffset};
+use combine::stream::state::State;
 use linked_hash_map::LinkedHashMap;
 use std::mem;
 use std::str::FromStr;

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -56,7 +56,7 @@ fn test_key_from_str() {
 }
 
 // wat?
-#[cfg_attr(feature = "cargo-clippy", allow(panic_params))]
+#[allow(clippy::panic_params)]
 #[test]
 fn test_value_from_str() {
     assert!(parse_value!("1979-05-27T00:32:00.999999-07:00").is_date_time());


### PR DESCRIPTION
This passes refs to table and path around, and avoids the use
of Cell and RefCell. It splits the job of walking the tree from
that of printing bytes by using the visitor pattern.

This is probably net-neutral for readability, but it allows
us to extend the formatting logic later if we need to.